### PR TITLE
修复划词搜索bug

### DIFF
--- a/WGestures.Core/Commands/Impl/WebSearchCommand.cs
+++ b/WGestures.Core/Commands/Impl/WebSearchCommand.cs
@@ -136,7 +136,7 @@ namespace WGestures.Core.Commands.Impl
 
         private string PopulateSearchEngingUrl(string param)
         {
-            return HttpUtility.UrlPathEncode(string.Format(SearchEngineUrl, param));
+            return string.Format(SearchEngineUrl, HttpUtility.UrlEncode(param));
         }
 
         public override string Description()


### PR DESCRIPTION
划词搜索时，当选中的词中包含特殊符号，如 test:test，会导致chrome浏览器打开新窗口或其他奇怪的行为
通过url编码解决该问题